### PR TITLE
Adds a 📊 reaction option to the replay details message for replay analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .envrc
+.idea/

--- a/analysis.go
+++ b/analysis.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+const (
+	analysisFieldName    = "Analysis"
+	chartEmoji           = "📊"
+	getReplayEndpoint    = "https://sc2replaystats.com/replay/"
+	uploadReplayEndpoint = "https://drop.sc/uploadReplay"
+)
+
+var (
+	cachedMe *discordgo.User
+)
+
+type DropScResponse struct {
+	Success                bool   `json:"success"`
+	HasReplayBeenProcessed bool   `json:"has_replay_been_processed"`
+	ReplayID               string `json:"replay_id"`
+}
+
+func handleMessageReactionSafe(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
+	err := handleMessageReaction(s, r)
+	if err != nil {
+		logger.Error("Error handling reaction, ", err)
+	}
+}
+
+func handleMessageReaction(s *discordgo.Session, r *discordgo.MessageReactionAdd) error {
+	me, err := getMe(s)
+
+	if err != nil {
+		logger.Error("error getting me, ", err)
+		return err
+	}
+
+	if r.UserID == me.ID {
+		// Ignore own reaction
+		return nil
+	}
+
+	message, err := s.ChannelMessage(r.ChannelID, r.MessageID)
+	if err != nil {
+		logger.Error("error retrieving message when handling reaction, ", err)
+		return err
+	}
+
+	if message == nil {
+		logger.Debug("message was nil when handling reaction")
+		return nil
+	}
+
+	if message.Author.ID != me.ID {
+		// Ignore reaction to message from different author
+		return nil
+	}
+
+	switch r.Emoji.Name {
+	case chartEmoji:
+		if len(message.Embeds) == 0 {
+			return errors.New("reacted message has no embeds")
+		}
+
+		embed := message.Embeds[0]
+
+		embedUrl := embed.URL
+		if !strings.HasSuffix(embedUrl, ".SC2Replay") {
+			return errors.New("embed url for reacted message is wrong format")
+		}
+
+		if len(embed.Fields) == 0 {
+			return errors.New("reacted message embed has no fields")
+		}
+
+		if embed.Fields[len(embed.Fields)-1].Name == analysisFieldName {
+			// ignore message which already has analysis
+			return nil
+		}
+
+		_, filename := path.Split(embedUrl)
+
+		resp, err := http.Get(embedUrl)
+		if err != nil {
+			logger.Error("Error requesting attachment, ", err)
+			return err
+		}
+
+		defer resp.Body.Close()
+
+		var b bytes.Buffer
+		mw := multipart.NewWriter(&b)
+		fw, err := mw.CreateFormFile("files[]", filename)
+		if err != nil {
+			logger.Error("Error creating upload request, ", err)
+			return err
+		}
+
+		_, err = io.Copy(fw, resp.Body)
+		if err != nil {
+			logger.Error("Error copying upload data, ", err)
+			return err
+		}
+
+		mw.Close()
+
+		contentType := "multipart/form-data; boundary=" + mw.Boundary()
+
+		resp, err = http.Post(uploadReplayEndpoint, contentType, &b)
+		if err != nil {
+			logger.Error("Error uploading replay, ", err)
+			return err
+		}
+
+		defer resp.Body.Close()
+
+		content, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Error("Error reading response, ", err)
+			return err
+		}
+
+		var dropScResponse DropScResponse
+		err = json.Unmarshal(content, &dropScResponse)
+		if err != nil {
+			logger.Error("Error unmarshalling drop sc response, ", err)
+			return err
+		}
+
+		if !dropScResponse.Success {
+			return errors.New("failed drop.sc upload")
+		}
+
+		replayLink := discordgo.MessageEmbedField{
+			Name:  analysisFieldName,
+			Value: getReplayEndpoint + dropScResponse.ReplayID,
+		}
+		embed.Fields = append(embed.Fields, &replayLink)
+
+		_, err = s.ChannelMessageEditEmbed(message.ChannelID, message.ID, embed)
+		if err != nil {
+			logger.Debug("Error editing embed, ", err)
+			return err
+		}
+
+	default:
+		// Ignore unrecognised emoji
+		return nil
+	}
+
+	return nil
+}
+
+func getMe(s *discordgo.Session) (*discordgo.User, error) {
+	if cachedMe != nil {
+		return cachedMe, nil
+	}
+
+	cachedMe, err := s.User("@me")
+	if err != nil {
+		return nil, err
+	}
+
+	if cachedMe == nil {
+		return nil, errors.New("me data was nil")
+	}
+
+	return cachedMe, nil
+}

--- a/main.go
+++ b/main.go
@@ -17,13 +17,13 @@ import (
 	"go.uber.org/zap"
 )
 
-const(
+const (
 	entryPointPid = 1
-	unknownEmoji = ":question:"
-	victoryEmoji = ":trophy:"
-	defeatEmoji = ":skull:"
-	tieEmoji = ":infinity:"
-	chartEmoji = "📊"
+	unknownEmoji  = ":question:"
+	victoryEmoji  = ":trophy:"
+	defeatEmoji   = ":skull:"
+	tieEmoji      = ":infinity:"
+	chartEmoji    = "📊"
 )
 
 var (
@@ -34,14 +34,14 @@ type Logger struct {
 	*zap.SugaredLogger
 }
 
-func (l Logger)Debug(args ...interface{}) {
-	l.Debugf("", "\n" + pp.Sprint(args))
+func (l Logger) Debug(args ...interface{}) {
+	l.Debugf("", "\n"+pp.Sprint(args))
 }
 
 func getLogger(isProd bool) Logger {
 	var (
 		_logger *zap.Logger
-		err error
+		err     error
 	)
 
 	if isProd {
@@ -54,7 +54,7 @@ func getLogger(isProd bool) Logger {
 		panic(err)
 	}
 
-  return Logger{ _logger.Sugar() }
+	return Logger{_logger.Sugar()}
 }
 
 func main() {
@@ -135,26 +135,26 @@ func handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 		embed := &discordgo.MessageEmbed{
 			Title: m.Message.Attachments[0].Filename,
-			URL: url,
+			URL:   url,
 			Fields: []*discordgo.MessageEmbedField{
 				{
-					Name: "Version",
+					Name:  "Version",
 					Value: replay.Header.VersionString(),
 				},
 				{
-					Name: "Region",
+					Name:  "Region",
 					Value: replay.InitData.GameDescription.Region().Code,
 				},
 				{
-					Name: "Time",
+					Name:  "Time",
 					Value: replay.Details.Time().String(),
 				},
 				{
-					Name: "Duration",
+					Name:  "Duration",
 					Value: replay.Header.Duration().String(),
 				},
 				{
-					Name: "Map",
+					Name:  "Map",
 					Value: replay.Details.Title(),
 				},
 			},
@@ -193,7 +193,7 @@ func handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			}
 
 			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-				Name: fmt.Sprintf("Team #%d %s", teamIndex + 1, result),
+				Name:  fmt.Sprintf("Team #%d %s", teamIndex+1, result),
 				Value: strings.Join(playerStrings, "\n"),
 			})
 		}

--- a/main.go
+++ b/main.go
@@ -158,6 +158,9 @@ func handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 					Value: replay.Details.Title(),
 				},
 			},
+			Footer: &discordgo.MessageEmbedFooter{
+				Text: "Reactions:\n" + chartEmoji + " - Show analysis",
+			},
 		}
 
 		teams := make([][]rep.Player, replay.InitData.GameDescription.MaxTeams())

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ const(
 	victoryEmoji = ":trophy:"
 	defeatEmoji = ":skull:"
 	tieEmoji = ":infinity:"
+	chartEmoji = "📊"
 )
 
 var (
@@ -48,7 +49,7 @@ func getLogger(isProd bool) Logger {
 	} else {
 		_logger, err = zap.NewDevelopment()
 	}
-	
+
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +79,7 @@ func main() {
 	}
 
 	logger.Info("Bot is now running.")
-	
+
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
@@ -110,7 +111,7 @@ func handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		// logger.Debug(resp)
 
 		defer resp.Body.Close()
-		
+
 		body, err := io.ReadAll(resp.Body)
 
 		if err != nil {
@@ -131,7 +132,7 @@ func handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		logger.Debug(replay.InitData.GameDescription)
 		logger.Debug(replay.InitData.GameDescription.Region())
 		logger.Debug(replay.Details.Players())
-		
+
 		embed := &discordgo.MessageEmbed{
 			Title: m.Message.Attachments[0].Filename,
 			URL: url,
@@ -199,11 +200,17 @@ func handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 		logger.Debug(embed)
 
-		newMessage, err:=s.ChannelMessageSendEmbed(m.ChannelID, embed)
+		newMessage, err := s.ChannelMessageSendEmbed(m.ChannelID, embed)
 		if err != nil {
 			logger.Error("Error sending message, ", err)
 			logger.Debug(err)
 		}
 		logger.Debug(newMessage)
+
+		err = s.MessageReactionAdd(m.ChannelID, newMessage.ID, chartEmoji)
+		if err != nil {
+			logger.Error("Error adding reactions to message, ", err)
+			logger.Debug(err)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ const (
 	victoryEmoji  = ":trophy:"
 	defeatEmoji   = ":skull:"
 	tieEmoji      = ":infinity:"
-	chartEmoji    = "📊"
 )
 
 var (
@@ -70,8 +69,9 @@ func main() {
 	}
 
 	dg.AddHandler(handleMessageCreate)
+	dg.AddHandler(handleMessageReactionSafe)
 
-	dg.Identify.Intents = discordgo.IntentsGuildMessages
+	dg.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsGuildMessageReactions
 
 	err = dg.Open()
 	if err != nil {


### PR DESCRIPTION
### Details
This change adds a 📊 emoji reaction to all newly created replay details messages. It listens to any additional user reactions for the same emoji, and if discovered, will upload the reacted-to replay to `Sc2ReplayStats` and provide a link to the replay analysis page.

Uploads to `Sc2ReplayStats` are performed via `Drop.sc`.

This implementation fully reads replay files into memory when uploading them.

This implementation does not include any replay caching, so all uploaded replays will be read twice - once to generate replay details and once for uploading.

### Test Plan
Manually tested happy path for handling 📊 emoji reaction - see following screenshots:
![image](https://user-images.githubusercontent.com/1161180/146974753-1476f096-1c87-441b-865b-6676b88437f3.png)

![image](https://user-images.githubusercontent.com/1161180/146974792-5fed635e-389d-4cac-b6dd-1fab18868d0d.png)

Sc2ReplayStats analysis page for replay above - https://sc2replaystats.com/replay/20604036